### PR TITLE
Add support for RS256 algorithm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+t/servroot
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:jessie
+
+WORKDIR /lua-resty-jwt
+
+ENV OPENRESTY_VERSION 1.7.10.1
+
+RUN apt-get update && \
+    apt-get install -y libpcre3 curl build-essential libpcre3-dev libssl-dev git unzip && \
+    curl http://openresty.org/download/ngx_openresty-${OPENRESTY_VERSION}.tar.gz | tar zxvf - && \
+    cd ngx_openresty-${OPENRESTY_VERSION} && \
+    ./configure --prefix=/usr && make && make install && \
+    cd ..; rm -rf ngx_openresty-${OPENRESTY_VERSION} && \
+    git clone https://github.com/openresty/test-nginx.git && \
+    cd test-nginx && \
+    perl Makefile.PL && \
+    make && \
+    make install && \
+    cpan install Test::Base && \
+    git clone --depth 1 https://github.com/jkeys089/lua-resty-hmac.git hmac && \
+    cp -r hmac/lib/resty/* /usr/lualib/resty/ && \
+    rm -rf hmac && \
+    curl http://keplerproject.github.io/luarocks/releases/luarocks-2.2.2.tar.gz | tar zxvf - &&\
+    cd luarocks-* && \
+    ./configure --prefix=/usr/luajit \
+    --with-lua=/usr/luajit/ \
+    --lua-suffix=jit-2.1.0-alpha \
+    --with-lua-include=/usr/luajit/include/luajit-2.1 && \
+    make build && make install && cd .. && \
+    ln -s /usr/luajit/bin/luarocks /usr/bin/luarocks && \
+    luarocks install luacheck && \
+    ln -s /usr/luajit/bin/luacheck /usr/bin/luacheck && \
+    apt-get -y autoremove && \
+    apt-get clean
+
+RUN ln -s /usr/nginx/sbin/nginx /usr/sbin/nginx
+
+COPY . /lua-resty-jwt/

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ and then load the library in Lua:
 
 [Back to TOC](#table-of-contents)
 
+Testing With Docker
+===================
+
+```
+docker build -t lua-resty-jwt .
+docker run --rm -it -v `pwd`:/lua-resty-jwt lua-resty-jwt make test
+```
+
 See Also
 ========
 * the ngx_lua module: http://wiki.nginx.org/HttpLuaModule

--- a/lib/resty/evp.lua
+++ b/lib/resty/evp.lua
@@ -1,0 +1,352 @@
+-- Copyright (C) by Daniel Hiltgen (daniel.hiltgen@docker.com)
+
+
+local ffi = require "ffi"
+local _C = ffi.C
+local _M = { _VERSION = '0.01' }
+
+
+local CONST = {
+    SHA256_DIGEST = "SHA256",
+}
+_M.CONST = CONST
+
+
+-- Reference: https://wiki.openssl.org/index.php/EVP_Signing_and_Verifying
+ffi.cdef[[
+// Error handling
+unsigned long ERR_get_error(void);
+const char * ERR_reason_error_string(unsigned long e);
+
+// Basic IO
+typedef struct bio_st BIO;
+typedef struct bio_method_st BIO_METHOD;
+BIO_METHOD *BIO_s_mem(void);
+BIO * BIO_new(BIO_METHOD *type);
+int	BIO_puts(BIO *bp,const char *buf);
+void BIO_vfree(BIO *a);
+int    BIO_write(BIO *b, const void *buf, int len);
+
+// RSA
+typedef struct rsa_st RSA;
+int RSA_size(const RSA *rsa);
+void RSA_free(RSA *rsa);
+typedef int pem_password_cb(char *buf, int size, int rwflag, void *userdata);
+RSA * PEM_read_bio_RSAPrivateKey(BIO *bp, RSA **rsa, pem_password_cb *cb,
+								void *u);
+RSA * PEM_read_bio_RSAPublicKey(BIO *bp, RSA **rsa, pem_password_cb *cb,
+                                void *u);
+
+// EVP PKEY
+typedef struct evp_pkey_st EVP_PKEY;
+typedef struct engine_st ENGINE;
+EVP_PKEY *EVP_PKEY_new(void);
+int EVP_PKEY_set1_RSA(EVP_PKEY *pkey,RSA *key);
+EVP_PKEY *EVP_PKEY_new_mac_key(int type, ENGINE *e,
+                               const unsigned char *key, int keylen);
+void EVP_PKEY_free(EVP_PKEY *key);
+int i2d_RSA(RSA *a, unsigned char **out);
+
+// X509
+typedef struct x509_st X509;
+X509 *PEM_read_bio_X509(BIO *bp, X509 **x, pem_password_cb *cb, void *u);
+EVP_PKEY *      X509_get_pubkey(X509 *x);
+void X509_free(X509 *a);
+void EVP_PKEY_free(EVP_PKEY *key);
+int i2d_X509(X509 *a, unsigned char **out);
+X509 *d2i_X509_bio(BIO *bp, X509 **x);
+
+// X509 store
+typedef struct x509_store_st X509_STORE;
+typedef struct X509_crl_st X509_CRL;
+X509_STORE *X509_STORE_new(void );
+int X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
+    // Use this if we want to load the certs directly from a variables
+int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x);
+int     X509_STORE_load_locations (X509_STORE *ctx,
+                const char *file, const char *dir);
+void X509_STORE_free(X509_STORE *v);
+
+// X509 store context
+typedef struct x509_store_ctx_st X509_STORE_CTX;
+X509_STORE_CTX *X509_STORE_CTX_new(void);
+int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
+                         X509 *x509, void *chain);
+int             X509_verify_cert(X509_STORE_CTX *ctx);
+void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
+int    X509_STORE_CTX_get_error(X509_STORE_CTX *ctx);
+const char *X509_verify_cert_error_string(long n);
+void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
+
+// EVP Sign/Verify
+typedef struct env_md_ctx_st EVP_MD_CTX;
+typedef struct env_md_st EVP_MD;
+typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+const EVP_MD *EVP_get_digestbyname(const char *name);
+EVP_MD_CTX *EVP_MD_CTX_create(void);
+void    EVP_MD_CTX_destroy(EVP_MD_CTX *ctx);
+int     EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+int     EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
+                        const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
+int     EVP_DigestUpdate(EVP_MD_CTX *ctx,const void *d,
+                         size_t cnt);
+int     EVP_DigestSignFinal(EVP_MD_CTX *ctx,
+                        unsigned char *sigret, size_t *siglen);
+
+int     EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
+                        const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
+int     EVP_DigestVerifyFinal(EVP_MD_CTX *ctx,
+                        unsigned char *sig, size_t siglen);
+
+// Fingerprints
+int X509_digest(const X509 *data,const EVP_MD *type,
+                unsigned char *md, unsigned int *len);
+
+]]
+
+
+local function _err(ret)
+    local code = _C.ERR_get_error()
+    if code == 0 then
+        return ret, "Zero error code (null arguments?)"
+    end
+    return ret, ffi.string(_C.ERR_reason_error_string(code))
+end
+
+
+local RSASigner = {}
+_M.RSASigner = RSASigner
+
+--- Create a new RSASigner
+-- @param pem_private_key A private key string in PEM format
+-- @returns RSASigner, err_string
+function RSASigner.new(self, pem_private_key)
+    local bio = _C.BIO_new(_C.BIO_s_mem())
+    ffi.gc(bio, _C.BIO_vfree)
+    if _C.BIO_puts(bio, pem_private_key) < 0 then
+        return _err()
+    end
+
+    -- TODO might want to support password protected private keys...
+    local rsa = _C.PEM_read_bio_RSAPrivateKey(bio, nil, nil, nil)
+    ffi.gc(rsa, _C.RSA_free)
+
+    local evp_pkey = _C.EVP_PKEY_new()
+    if not evp_pkey then
+        return _err()
+    end
+    ffi.gc(evp_pkey, _C.EVP_PKEY_free)
+    if _C.EVP_PKEY_set1_RSA(evp_pkey, rsa) ~= 1 then
+        return _err()
+    end
+    self.evp_pkey = evp_pkey
+    return self, nil
+end
+
+
+--- Sign a message
+-- @param message The message to sign
+-- @param digest_name The digest format to use (e.g., "SHA256")
+-- @returns signature, error_string
+function RSASigner.sign(self, message, digest_name)
+    local buf = ffi.new("unsigned char[?]", 1024)
+    local len = ffi.new("size_t[1]", 1024)
+
+    local ctx = _C.EVP_MD_CTX_create()
+    if not ctx then
+        return _err()
+    end
+    ffi.gc(ctx, _C.EVP_MD_CTX_destroy)
+
+    local md = _C.EVP_get_digestbyname(digest_name)
+    if not md then
+        return _err()
+    end
+
+    if _C.EVP_DigestInit_ex(ctx, md, nil) ~= 1 then
+        return _err()
+    end
+    local ret = _C.EVP_DigestSignInit(ctx, nil, md, nil, self.evp_pkey)
+    if  ret ~= 1 then
+        return _err()
+    end
+    if _C.EVP_DigestUpdate(ctx, message, #message) ~= 1 then
+         return _err()
+    end
+    if _C.EVP_DigestSignFinal(ctx, buf, len) ~= 1 then
+        return _err()
+    end
+    return ffi.string(buf, len[0]), nil
+end
+
+
+
+local RSAVerifier = {}
+_M.RSAVerifier = RSAVerifier
+
+
+--- Create a new RSAVerifier
+-- @param cert An instance of Cert used for verification
+-- @returns RSAVerifier, error_string
+function RSAVerifier.new(self, cert)
+    if not cert then
+        return nil, "You must pass in an Cert for a public key"
+    end
+    local evp_public_key, err = cert:get_public_key()
+    if not evp_public_key then
+        return nil, err
+    end
+
+    self.evp_pkey = evp_public_key
+    return self, nil
+end
+
+--- Verify a message is properly signed
+-- @param message The original message
+-- @param the signature to verify
+-- @param digest_name The digest type that was used to sign
+-- @returns bool, error_string
+function RSAVerifier.verify(self, message, sig, digest_name)
+    local md = _C.EVP_get_digestbyname(digest_name)
+    if not md then
+        return _err(false)
+    end
+
+    local ctx = _C.EVP_MD_CTX_create()
+    if not ctx then
+        return _err(false)
+    end
+    ffi.gc(ctx, _C.EVP_MD_CTX_destroy)
+
+    if _C.EVP_DigestInit_ex(ctx, md, nil) ~= 1 then
+        return _err(false)
+    end
+
+    local ret = _C.EVP_DigestVerifyInit(ctx, nil, md, nil, self.evp_pkey)
+    if ret ~= 1 then
+        return _err(false)
+    end
+    if _C.EVP_DigestUpdate(ctx, message, #message) ~= 1 then
+        return _err(false)
+    end
+    local sig_bin = ffi.new("unsigned char[?]", #sig)
+    ffi.copy(sig_bin, sig, #sig)
+    if _C.EVP_DigestVerifyFinal(ctx, sig_bin, #sig) == 1 then
+        return true, nil
+    else
+        return false, "Verification failed"
+    end
+end
+
+
+local Cert = {}
+_M.Cert = Cert
+
+
+--- Create a new Certificate object
+-- @param payload A PEM or DER format X509 certificate
+-- @returns Cert, error_string
+function Cert.new(self, payload)
+    if not payload then
+        return nil, "Must pass a PEM or binary DER cert"
+    end
+    local bio = _C.BIO_new(_C.BIO_s_mem())
+    ffi.gc(bio, _C.BIO_vfree)
+    local x509
+    if payload:find('-----BEGIN') then
+        if _C.BIO_puts(bio, payload) < 0 then
+            return _err()
+        end
+        x509 = _C.PEM_read_bio_X509(bio, nil, nil, nil)
+    else
+        if _C.BIO_write(bio, payload, #payload) < 0 then
+            return _err()
+        end
+        x509 = _C.d2i_X509_bio(bio, nil)
+    end
+    if not x509 then
+        return _err()
+    end
+    ffi.gc(x509, _C.X509_free)
+    self.x509 = x509
+    return self, nil
+end
+
+
+--- Retrieve the DER format of the certificate
+-- @returns Binary DER format
+function Cert.get_der(self)
+    local bufp = ffi.new("unsigned char *[1]")
+    local len = _C.i2d_X509(self.x509, bufp)
+    if len < 0 then
+        return _err()
+    end
+    local der = ffi.string(bufp[0], len)
+    return der, nil
+end
+
+--- Retrieve the cert fingerprint
+-- @param digest_name the Type of digest to use (e.g., "SHA256")
+-- @returns fingerprint_string
+function Cert.get_fingerprint(self, digest_name)
+    local md = _C.EVP_get_digestbyname(digest_name)
+    if not md then
+        return _err()
+    end
+    local buf = ffi.new("unsigned char[?]", 32)
+    local len = ffi.new("unsigned int[1]", 32)
+    if _C.X509_digest(self.x509, md, buf, len) ~= 1 then
+        return _err()
+    end
+    local raw = ffi.string(buf, len[0])
+    local t = {}
+    raw:gsub('.', function (c) table.insert(t, string.format('%02X', string.byte(c))) end)
+    return table.concat(t, ":"), nil
+end
+
+--- Retrieve the public key from the CERT
+-- @returns An OpenSSL EVP PKEY object representing the public key
+function Cert.get_public_key(self)
+    local evp_pkey = _C.X509_get_pubkey(self.x509)
+    if not evp_pkey then
+        return _err()
+    end
+
+    return evp_pkey, nil
+end
+
+--- Verify the Certificate is trusted
+-- @param trusted_cert_file File path to a list of PEM encoded trusted certificates
+-- @return bool, error_string
+function Cert.verify_trust(self, trusted_cert_file)
+    local store = _C.X509_STORE_new()
+    if not store then
+        return _err(false)
+    end
+    ffi.gc(store, _C.X509_STORE_free)
+    if _C.X509_STORE_load_locations(store, trusted_cert_file, nil) ~=1 then
+        return _err(false)
+    end
+
+    local ctx = _C.X509_STORE_CTX_new()
+    if not store then
+        return _err(false)
+    end
+    ffi.gc(ctx, _C.X509_STORE_CTX_free)
+    if _C.X509_STORE_CTX_init(ctx, store, self.x509, nil) ~= 1 then
+        return _err(false)
+    end
+
+    if _C.X509_verify_cert(ctx) ~= 1 then
+        local code = _C.X509_STORE_CTX_get_error(ctx)
+        local msg = ffi.string(_C.X509_verify_cert_error_string(code))
+        _C.X509_STORE_CTX_cleanup(ctx)
+        return false, msg
+    end
+    _C.X509_STORE_CTX_cleanup(ctx)
+    return true, nil
+
+end
+
+
+return _M

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -2,6 +2,7 @@ local cjson = require "cjson"
 local hmac = require "resty.hmac"
 
 local _M = {_VERSION="0.1.0"}
+local evp = require "resty.evp"
 local mt = {__index=_M}
 
 
@@ -68,6 +69,24 @@ function _M.jwt_decode(self, b64_str, json_decode)
     return data
 end
 
+--- Initialize the trusted certs
+-- During RS256 verify, we'll make sure the
+-- cert was signed by one of these
+function _M.set_trusted_certs_file(self, filename)
+    self.trusted_certs_file = filename
+end
+_M.trusted_certs_file = nil
+
+--- Set a whitelist of allowed algorithms
+-- E.g., jwt:set_alg_whitelist({RS256=1,HS256=1})
+--
+-- @param algorithms - A table with keys for the supported algorithms
+--                     If the table is non-nil, during
+--                     verify, the alg must be in the table
+function _M.set_alg_whitelist(self, algorithms)
+    self.alg_whitelist = algorithms
+end
+_M.alg_whitelist = nil
 
 function _M.sign(self, secret_key, jwt_obj)
     -- header typ check
@@ -75,26 +94,31 @@ function _M.sign(self, secret_key, jwt_obj)
     if typ ~= "JWT" then
         error({reason="invalid typ: " .. typ})
     end
-    -- header alg check
-    local alg = jwt_obj["header"]["alg"]
-    local hash_alg = nil
-    if alg == "HS256" then
-        hash_alg = hmac.ALGOS.SHA256
-    elseif alg == "HS512" then
-        hash_alg = hmac.ALGOS.SHA512
-    else
-        error({reason="unsupported alg: " .. alg})
-    end
+
     -- assemble jwt parts
     local raw_header = get_raw_part("header", jwt_obj)
     local raw_payload = get_raw_part("payload", jwt_obj)
 
     local message =raw_header ..  "." ..  raw_payload
-    -- cal signature
-    local hmac_func = hmac:new(secret_key, hash_alg)
-    local signature = _M:jwt_encode(hmac_func:final(message))
+
+    -- header alg check
+    local alg = jwt_obj["header"]["alg"]
+    local signature = ""
+    if alg == "HS256" then
+        signature = hmac:new(secret_key, hmac.ALGOS.SHA256):final(message)
+    elseif alg == "HS512" then
+        signature = hmac:new(secret_key, hmac.ALGOS.SHA512):final(message)
+    elseif alg == "RS256" then
+        local signer, err = evp.RSASigner:new(secret_key)
+        if not signer then
+            error({reason="signer error: " .. err})
+        end
+        signature = signer:sign(message, evp.CONST.SHA256_DIGEST)
+    else
+        error({reason="unsupported alg: " .. alg})
+    end
     -- return full jwt string
-    return message .. "." .. signature
+    return message .. "." .. _M:jwt_encode(signature)
 end
 
 
@@ -116,21 +140,86 @@ end
 
 
 function _M.verify_jwt_obj(self, secret, jwt_obj, leeway)
-    local jwt_str = jwt_obj.raw_header .. 
+    local jwt_str = jwt_obj.raw_header ..
         "." .. jwt_obj.raw_payload ..
         "." .. jwt_obj.signature
 
     if not jwt_obj.valid then
         return jwt_obj
     end
-    local success, ret = pcall(_M.sign, self, secret, jwt_obj)
-    if not success then
-        -- syntax check
-        jwt_obj["reason"] = ret["reason"] or "internal error"
-    elseif jwt_str ~= ret then
-        -- signature check
-        jwt_obj["reason"] = "signature mismatch: " .. jwt_obj["signature"]
-    elseif leeway ~= nil then
+    local alg = jwt_obj["header"]["alg"]
+    if self.alg_whitelist ~= nil then
+        if self.alg_whitelist[alg] == nil then
+            return {verified=false, reason="whitelist unsupported alg: " .. alg}
+        end
+    end
+    if alg == "HS256" or alg == "HS512" then
+        local success, ret = pcall(_M.sign, self, secret, jwt_obj)
+        if not success then
+            -- syntax check
+            jwt_obj["reason"] = ret["reason"] or "internal error"
+        elseif jwt_str ~= ret then
+            -- signature check
+            jwt_obj["reason"] = "signature mismatch: " .. jwt_obj["signature"]
+        end
+    elseif alg == "RS256" then
+        local x5c = jwt_obj['header']['x5c']
+        if not x5c or not x5c[1] then
+            jwt_obj["reason"] = "Unsupported RS256 key model"
+            return jwt_obj
+            -- TODO - Implement jwk and kid based models...
+        end
+
+        -- TODO Might want to add support for intermediaries that we
+        -- don't have in our trusted chain (items 2... if present)
+        local cert_str = ngx.decode_base64(x5c[1])
+        if not cert_str then
+            jwt_obj["reason"] = "Malformed x5c header"
+            return jwt_obj
+        end
+        local cert, err = evp.Cert:new(cert_str)
+        if not cert then
+            jwt_obj["reason"] = "Unable to extract signing cert from JWT: " .. err
+            return jwt_obj
+        end
+        -- Try validating against trusted CA's, then a cert passed as secret
+        if self.trusted_certs_file ~= nil then
+            local trusted, err = cert:verify_trust(self.trusted_certs_file)
+            if not trusted then
+                jwt_obj["reason"] = "Cert used to sign the JWT isn't trusted: " .. err
+                return jwt_obj
+            end
+        elseif secret ~= nil then
+            cert, err = evp.Cert:new(secret)
+            if not cert then
+                jwt_obj["reason"] = "Decode secret is not a valid cert: " .. err
+                return jwt_obj
+            end
+        else
+            jwt_obj["reason"] = "No trusted certs loaded"
+            return jwt_obj
+        end
+        local verifier, err = evp.RSAVerifier:new(cert)
+        if not verifier then
+            -- Internal error case, should not happen...
+            jwt_obj["reason"] = "Failed to build verifier " .. err
+            return jwt_obj
+        end
+
+        -- assemble jwt parts
+        local raw_header = get_raw_part("header", jwt_obj)
+        local raw_payload = get_raw_part("payload", jwt_obj)
+
+        local message =raw_header ..  "." ..  raw_payload
+        local sig = jwt_obj["signature"]:gsub("-", "+"):gsub("_", "/")
+        local verified, err = verifier:verify(message, _M:jwt_decode(sig, false), evp.CONST.SHA256_DIGEST)
+        if not verified then
+            jwt_obj["reason"] = err
+        end
+    else
+        jwt_obj["reason"] = "Unsupported algorithm " .. alg
+    end
+    if leeway ~= nil and not jwt_obj["reason"] then
         local exp = jwt_obj["payload"]["exp"]
         local nbf = jwt_obj["payload"]["nbf"]
         local now = ngx.now()
@@ -144,7 +233,7 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, leeway)
         end
     end
 
-    if jwt_obj["reason"] == nil then
+    if not jwt_obj["reason"] then
         jwt_obj["verified"] = true
         jwt_obj["reason"] = "everything is awesome~ :p"
     end

--- a/t/sign-verify.t
+++ b/t/sign-verify.t
@@ -296,3 +296,143 @@ everything is awesome~ :p
 bar
 --- no_error_log
 [error]
+
+
+=== TEST 16: JWT sign and verify RS256
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        set $cert '-----BEGIN CERTIFICATE-----\nMIIEEDCCAvigAwIBAgIBATANBgkqhkiG9w0BAQUFADCBhDETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBmRvY2tlcjETMBEGA1UECgwKRG9ja2Vy\nIEluYzEfMB0GA1UECwwWRG9ja2VyIFRlc3QgU2lnbmluZyBDQTEfMB0GA1UEAwwW\nRG9ja2VyIFRlc3QgU2lnbmluZyBDQTAeFw0xNTA1MTMyMzAxMzlaFw0xNzA1MTIy\nMzAxMzlaMGsxEzARBgoJkiaJk/IsZAEZFgNjb20xFjAUBgoJkiaJk/IsZAEZFgZk\nb2NrZXIxEzARBgNVBAoMCkRvY2tlciBJbmMxDDAKBgNVBAsMA2h1YjEZMBcGA1UE\nAwwQaHViZ3cuZG9ja2VyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\nggEBANt4HzdXTDX9yklf5wemrt39peRmdJAHpodYn3PQBhkv8VGEU5+kpV8M9zg5\nj7SSjOED9+3LZ09l6iTBT+dQCJMEgyHN1gHPzkyjklrKfCC6yIKUIt+I/oUoHm3e\nloACrJZXYniZxCpiDf5JeitHCaVxJRGj+MXORe5SVY+V7MLlA3NSDHX6gIhknq59\nBOmSVJyww3Ka54kYtZwz3KZzMdrfvCdkjiCeD1zMJwYX6IU9z746DfHNuMnsH7Di\nmrzhoX/3CMFj9sXdpcrzFSlMDqUxIQunFyN6G4JKZywf9Dvs30Ay6q8gBhursRFd\nx6otDl0z7tqfJkA3e4GSt4/DR7MCAwEAAaOBpDCBoTAOBgNVHQ8BAf8EBAMCBLAw\nCQYDVR0TBAIwADAnBgNVHSUEIDAeBggrBgEFBQcDAQYIKwYBBQUHAwIGCCsGAQUF\nBwMDMB0GA1UdDgQWBBQa440jFVFkVPsnGp3sp2bEdtz+6jAfBgNVHSMEGDAWgBQi\nzqX0zdgLeF6GAy7a+zvT4pBCLjAbBgNVHREEFDASghBodWJndy5kb2NrZXIuY29t\nMA0GCSqGSIb3DQEBBQUAA4IBAQB8PdN14gs6zB2m2eB1JpyoFSwho4O1z9UkZqdb\nGUB5SmElVydR2nOMLLUuJoa1zTd1FcX0zlHtDKuRXmO7xaPtrH4Uxiq3Lpu7i2WB\nUDTnMXuzX7hzc5DeU7k7mMbwKRkb+kijJTkET6wcaJwwDSyhzOCZgXW3V0WjHdbD\nprJc52tUk3CHOZY8iZWDVf9gHQpVeJnKzospXJRs3qQksEzD6ciRXu0VHnxeC0DP\n5pnQC17Kkm1QOCHRrsIGDHk9wB1zJlMoeMgIPrCLcC0GappmUlHSMka+3MZYgeW4\nAVlzdia3EYSUuM8Gb5tjSSm/6rTOnXR+zL4PBhNZdAD17hyY\n-----END CERTIFICATE-----';
+        set $key '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDbeB83V0w1/cpJ\nX+cHpq7d/aXkZnSQB6aHWJ9z0AYZL/FRhFOfpKVfDPc4OY+0kozhA/fty2dPZeok\nwU/nUAiTBIMhzdYBz85Mo5JaynwgusiClCLfiP6FKB5t3paAAqyWV2J4mcQqYg3+\nSXorRwmlcSURo/jFzkXuUlWPlezC5QNzUgx1+oCIZJ6ufQTpklScsMNymueJGLWc\nM9ymczHa37wnZI4gng9czCcGF+iFPc++Og3xzbjJ7B+w4pq84aF/9wjBY/bF3aXK\n8xUpTA6lMSELpxcjehuCSmcsH/Q77N9AMuqvIAYbq7ERXceqLQ5dM+7anyZAN3uB\nkrePw0ezAgMBAAECggEBAIZga0SYN/qK9ROuG6fsn/8eMjfBn7ccaBNQ6PihM0qy\ntyABVK5XwkWLi8cqP1oBrS6NHn3D3/KWZSGyFzl7IHTb+2p0PIeJdDgqow7iEdR8\naQ7CowOZPrXLFa6R7jZc7M10nb9X7utAdG7xEFN1QGvC9j5x1n1OyjScxvSOiJPf\nQMyR7pAUW3GoNYBdgs8YWmMU7SiS8hp4LRsQ2aJpZUexUVk3o1E3ZIeM/joE+jFZ\nNX+rL0Aqmn0JVgKqZI2CbDB5AwJdSpUYd/m0Ko3E/Hxdu/CbeJqdjSl4ArVIyRBL\nJWY4aMbC81B6ftYGyjpBujXIoyTYNIhf+CYYXzNrsOkCgYEA8J4ajDpKtxowkbIj\nT+9FTY54d+SWcvwEKA22KayyFwx/mXWTnfsylzF6JbGAiZKSG9gbUOP1LsoGDsGj\nhFdLMSfmi151IbOJg1l74E7nM5bqW9ULGyLBOpWlvopXt31jV6uQd/t/+gdflyw0\nMtr642krwfz8UOshkeEIsk+7mmUCgYEA6X/omGsvMyLpa2IWjxwuw+51pCdIoZvL\n7BpV1YHqwO8jWVv1KKpOKzrYZVu93w0WMCHoG/g9FGQtOBmMRk2OKOxmCF+H1or4\nI1+iI/dhTPA2tEeAELX+yGtu4fpEHe+dga1QCNdq06366rn0bhWB5hst1DdVQnXn\n+0KjhLmg7DcCgYAxqQ/lnSpKfBdGGrP7DXEKPrtSU1VRyf25norYMxJWe3fiXkfn\nNS8N0WJaYTYcLqoFIScSHNo/m+aAKSrsZ2/XZ1rHrOkT2ZAqEc/lTaOeHCmmZmPy\nZ8vloXkhyD+uWSylrX0VpkyVd+wcsTzcuiFJyi0Dzojs0nqNNxqqYpZfmQKBgDep\npUIIcyUGkoxlwqj09/T/OI4cS0UzRaaQFJwkL1k06MFZmZTLHH1TtthayWWN0hdB\nTfq076KXyuvPs0/jFxuMVzpxw4kScdrE5nsactiLfw706IOTTxxp9/Ho3iogv/R0\n41poN/AkTmd8UteXSvMW0ZMAadPBFb8hAKgYNFN7AoGAbw6WYYPnhikP7gqWmTh0\n0SOeET5WbRfseiUWMfLGL+R5GmNiBhw63n8srz+KJVLJv0PJ/WKDR7o/Hxjv3w9c\ndkqcFG1MW2NKjrdxztptrRaSD7JyA750rB+CsrwvqzJCvwbulp1iRfWkTqq2fnUU\nQvpxhOYnq/ZlXPjUiE5w67w=\n-----END PRIVATE KEY-----';
+        set $pub_key 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA23gfN1dMNf3KSV/nB6au3f2l5GZ0kAemh1ifc9AGGS/xUYRTn6SlXwz3ODmPtJKM4QP37ctnT2XqJMFP51AIkwSDIc3WAc/OTKOSWsp8ILrIgpQi34j+hSgebd6WgAKslldieJnEKmIN/kl6K0cJpXElEaP4xc5F7lJVj5XswuUDc1IMdfqAiGSern0E6ZJUnLDDcprniRi1nDPcpnMx2t+8J2SOIJ4PXMwnBhfohT3PvjoN8c24yewfsOKavOGhf/cIwWP2xd2lyvMVKUwOpTEhC6cXI3obgkpnLB/0O+zfQDLqryAGG6uxEV3Hqi0OXTPu2p8mQDd7gZK3j8NHswIDAQAB';
+        content_by_lua '
+            local jwt = require "resty.jwt"
+
+            local jwt_token = jwt:sign(
+                ngx.var.key,
+                {
+                    header={
+                        typ="JWT",
+                        alg="RS256",
+                        x5c={
+                            ngx.var.pub_key,
+                        } },
+                    payload={foo="bar"}
+                }
+            )
+
+            local jwt_obj = jwt:verify(ngx.var.cert, jwt_token)
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+            ngx.say(jwt_obj["payload"]["foo"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+everything is awesome~ :p
+bar
+--- no_error_log
+[error]
+
+
+=== TEST 17: RS256 malformed header
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        set $cert '-----BEGIN CERTIFICATE-----\nMIIEEDCCAvigAwIBAgIBATANBgkqhkiG9w0BAQUFADCBhDETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBmRvY2tlcjETMBEGA1UECgwKRG9ja2Vy\nIEluYzEfMB0GA1UECwwWRG9ja2VyIFRlc3QgU2lnbmluZyBDQTEfMB0GA1UEAwwW\nRG9ja2VyIFRlc3QgU2lnbmluZyBDQTAeFw0xNTA1MTMyMzAxMzlaFw0xNzA1MTIy\nMzAxMzlaMGsxEzARBgoJkiaJk/IsZAEZFgNjb20xFjAUBgoJkiaJk/IsZAEZFgZk\nb2NrZXIxEzARBgNVBAoMCkRvY2tlciBJbmMxDDAKBgNVBAsMA2h1YjEZMBcGA1UE\nAwwQaHViZ3cuZG9ja2VyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\nggEBANt4HzdXTDX9yklf5wemrt39peRmdJAHpodYn3PQBhkv8VGEU5+kpV8M9zg5\nj7SSjOED9+3LZ09l6iTBT+dQCJMEgyHN1gHPzkyjklrKfCC6yIKUIt+I/oUoHm3e\nloACrJZXYniZxCpiDf5JeitHCaVxJRGj+MXORe5SVY+V7MLlA3NSDHX6gIhknq59\nBOmSVJyww3Ka54kYtZwz3KZzMdrfvCdkjiCeD1zMJwYX6IU9z746DfHNuMnsH7Di\nmrzhoX/3CMFj9sXdpcrzFSlMDqUxIQunFyN6G4JKZywf9Dvs30Ay6q8gBhursRFd\nx6otDl0z7tqfJkA3e4GSt4/DR7MCAwEAAaOBpDCBoTAOBgNVHQ8BAf8EBAMCBLAw\nCQYDVR0TBAIwADAnBgNVHSUEIDAeBggrBgEFBQcDAQYIKwYBBQUHAwIGCCsGAQUF\nBwMDMB0GA1UdDgQWBBQa440jFVFkVPsnGp3sp2bEdtz+6jAfBgNVHSMEGDAWgBQi\nzqX0zdgLeF6GAy7a+zvT4pBCLjAbBgNVHREEFDASghBodWJndy5kb2NrZXIuY29t\nMA0GCSqGSIb3DQEBBQUAA4IBAQB8PdN14gs6zB2m2eB1JpyoFSwho4O1z9UkZqdb\nGUB5SmElVydR2nOMLLUuJoa1zTd1FcX0zlHtDKuRXmO7xaPtrH4Uxiq3Lpu7i2WB\nUDTnMXuzX7hzc5DeU7k7mMbwKRkb+kijJTkET6wcaJwwDSyhzOCZgXW3V0WjHdbD\nprJc52tUk3CHOZY8iZWDVf9gHQpVeJnKzospXJRs3qQksEzD6ciRXu0VHnxeC0DP\n5pnQC17Kkm1QOCHRrsIGDHk9wB1zJlMoeMgIPrCLcC0GappmUlHSMka+3MZYgeW4\nAVlzdia3EYSUuM8Gb5tjSSm/6rTOnXR+zL4PBhNZdAD17hyY\n-----END CERTIFICATE-----';
+        set $key '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDbeB83V0w1/cpJ\nX+cHpq7d/aXkZnSQB6aHWJ9z0AYZL/FRhFOfpKVfDPc4OY+0kozhA/fty2dPZeok\nwU/nUAiTBIMhzdYBz85Mo5JaynwgusiClCLfiP6FKB5t3paAAqyWV2J4mcQqYg3+\nSXorRwmlcSURo/jFzkXuUlWPlezC5QNzUgx1+oCIZJ6ufQTpklScsMNymueJGLWc\nM9ymczHa37wnZI4gng9czCcGF+iFPc++Og3xzbjJ7B+w4pq84aF/9wjBY/bF3aXK\n8xUpTA6lMSELpxcjehuCSmcsH/Q77N9AMuqvIAYbq7ERXceqLQ5dM+7anyZAN3uB\nkrePw0ezAgMBAAECggEBAIZga0SYN/qK9ROuG6fsn/8eMjfBn7ccaBNQ6PihM0qy\ntyABVK5XwkWLi8cqP1oBrS6NHn3D3/KWZSGyFzl7IHTb+2p0PIeJdDgqow7iEdR8\naQ7CowOZPrXLFa6R7jZc7M10nb9X7utAdG7xEFN1QGvC9j5x1n1OyjScxvSOiJPf\nQMyR7pAUW3GoNYBdgs8YWmMU7SiS8hp4LRsQ2aJpZUexUVk3o1E3ZIeM/joE+jFZ\nNX+rL0Aqmn0JVgKqZI2CbDB5AwJdSpUYd/m0Ko3E/Hxdu/CbeJqdjSl4ArVIyRBL\nJWY4aMbC81B6ftYGyjpBujXIoyTYNIhf+CYYXzNrsOkCgYEA8J4ajDpKtxowkbIj\nT+9FTY54d+SWcvwEKA22KayyFwx/mXWTnfsylzF6JbGAiZKSG9gbUOP1LsoGDsGj\nhFdLMSfmi151IbOJg1l74E7nM5bqW9ULGyLBOpWlvopXt31jV6uQd/t/+gdflyw0\nMtr642krwfz8UOshkeEIsk+7mmUCgYEA6X/omGsvMyLpa2IWjxwuw+51pCdIoZvL\n7BpV1YHqwO8jWVv1KKpOKzrYZVu93w0WMCHoG/g9FGQtOBmMRk2OKOxmCF+H1or4\nI1+iI/dhTPA2tEeAELX+yGtu4fpEHe+dga1QCNdq06366rn0bhWB5hst1DdVQnXn\n+0KjhLmg7DcCgYAxqQ/lnSpKfBdGGrP7DXEKPrtSU1VRyf25norYMxJWe3fiXkfn\nNS8N0WJaYTYcLqoFIScSHNo/m+aAKSrsZ2/XZ1rHrOkT2ZAqEc/lTaOeHCmmZmPy\nZ8vloXkhyD+uWSylrX0VpkyVd+wcsTzcuiFJyi0Dzojs0nqNNxqqYpZfmQKBgDep\npUIIcyUGkoxlwqj09/T/OI4cS0UzRaaQFJwkL1k06MFZmZTLHH1TtthayWWN0hdB\nTfq076KXyuvPs0/jFxuMVzpxw4kScdrE5nsactiLfw706IOTTxxp9/Ho3iogv/R0\n41poN/AkTmd8UteXSvMW0ZMAadPBFb8hAKgYNFN7AoGAbw6WYYPnhikP7gqWmTh0\n0SOeET5WbRfseiUWMfLGL+R5GmNiBhw63n8srz+KJVLJv0PJ/WKDR7o/Hxjv3w9c\ndkqcFG1MW2NKjrdxztptrRaSD7JyA750rB+CsrwvqzJCvwbulp1iRfWkTqq2fnUU\nQvpxhOYnq/ZlXPjUiE5w67w=\n-----END PRIVATE KEY-----';
+        content_by_lua '
+            local jwt = require "resty.jwt"
+
+            local jwt_token = jwt:sign(
+                ngx.var.key,
+                {
+                    header={
+                        typ="JWT",
+                        alg="RS256",
+                        x5c={nil, } },
+                    payload={foo="bar"}
+                }
+            )
+
+            local jwt_obj = jwt:verify(ngx.var.cert, jwt_token)
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+            ngx.say(jwt_obj["payload"]["foo"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+Unsupported RS256 key model
+bar
+--- no_error_log
+[error]
+
+
+=== TEST 18: RS256 malformed header 2
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        set $cert '-----BEGIN CERTIFICATE-----\nMIIEEDCCAvigAwIBAgIBATANBgkqhkiG9w0BAQUFADCBhDETMBEGCgmSJomT8ixk\nARkWA2NvbTEWMBQGCgmSJomT8ixkARkWBmRvY2tlcjETMBEGA1UECgwKRG9ja2Vy\nIEluYzEfMB0GA1UECwwWRG9ja2VyIFRlc3QgU2lnbmluZyBDQTEfMB0GA1UEAwwW\nRG9ja2VyIFRlc3QgU2lnbmluZyBDQTAeFw0xNTA1MTMyMzAxMzlaFw0xNzA1MTIy\nMzAxMzlaMGsxEzARBgoJkiaJk/IsZAEZFgNjb20xFjAUBgoJkiaJk/IsZAEZFgZk\nb2NrZXIxEzARBgNVBAoMCkRvY2tlciBJbmMxDDAKBgNVBAsMA2h1YjEZMBcGA1UE\nAwwQaHViZ3cuZG9ja2VyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC\nggEBANt4HzdXTDX9yklf5wemrt39peRmdJAHpodYn3PQBhkv8VGEU5+kpV8M9zg5\nj7SSjOED9+3LZ09l6iTBT+dQCJMEgyHN1gHPzkyjklrKfCC6yIKUIt+I/oUoHm3e\nloACrJZXYniZxCpiDf5JeitHCaVxJRGj+MXORe5SVY+V7MLlA3NSDHX6gIhknq59\nBOmSVJyww3Ka54kYtZwz3KZzMdrfvCdkjiCeD1zMJwYX6IU9z746DfHNuMnsH7Di\nmrzhoX/3CMFj9sXdpcrzFSlMDqUxIQunFyN6G4JKZywf9Dvs30Ay6q8gBhursRFd\nx6otDl0z7tqfJkA3e4GSt4/DR7MCAwEAAaOBpDCBoTAOBgNVHQ8BAf8EBAMCBLAw\nCQYDVR0TBAIwADAnBgNVHSUEIDAeBggrBgEFBQcDAQYIKwYBBQUHAwIGCCsGAQUF\nBwMDMB0GA1UdDgQWBBQa440jFVFkVPsnGp3sp2bEdtz+6jAfBgNVHSMEGDAWgBQi\nzqX0zdgLeF6GAy7a+zvT4pBCLjAbBgNVHREEFDASghBodWJndy5kb2NrZXIuY29t\nMA0GCSqGSIb3DQEBBQUAA4IBAQB8PdN14gs6zB2m2eB1JpyoFSwho4O1z9UkZqdb\nGUB5SmElVydR2nOMLLUuJoa1zTd1FcX0zlHtDKuRXmO7xaPtrH4Uxiq3Lpu7i2WB\nUDTnMXuzX7hzc5DeU7k7mMbwKRkb+kijJTkET6wcaJwwDSyhzOCZgXW3V0WjHdbD\nprJc52tUk3CHOZY8iZWDVf9gHQpVeJnKzospXJRs3qQksEzD6ciRXu0VHnxeC0DP\n5pnQC17Kkm1QOCHRrsIGDHk9wB1zJlMoeMgIPrCLcC0GappmUlHSMka+3MZYgeW4\nAVlzdia3EYSUuM8Gb5tjSSm/6rTOnXR+zL4PBhNZdAD17hyY\n-----END CERTIFICATE-----';
+        set $key '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDbeB83V0w1/cpJ\nX+cHpq7d/aXkZnSQB6aHWJ9z0AYZL/FRhFOfpKVfDPc4OY+0kozhA/fty2dPZeok\nwU/nUAiTBIMhzdYBz85Mo5JaynwgusiClCLfiP6FKB5t3paAAqyWV2J4mcQqYg3+\nSXorRwmlcSURo/jFzkXuUlWPlezC5QNzUgx1+oCIZJ6ufQTpklScsMNymueJGLWc\nM9ymczHa37wnZI4gng9czCcGF+iFPc++Og3xzbjJ7B+w4pq84aF/9wjBY/bF3aXK\n8xUpTA6lMSELpxcjehuCSmcsH/Q77N9AMuqvIAYbq7ERXceqLQ5dM+7anyZAN3uB\nkrePw0ezAgMBAAECggEBAIZga0SYN/qK9ROuG6fsn/8eMjfBn7ccaBNQ6PihM0qy\ntyABVK5XwkWLi8cqP1oBrS6NHn3D3/KWZSGyFzl7IHTb+2p0PIeJdDgqow7iEdR8\naQ7CowOZPrXLFa6R7jZc7M10nb9X7utAdG7xEFN1QGvC9j5x1n1OyjScxvSOiJPf\nQMyR7pAUW3GoNYBdgs8YWmMU7SiS8hp4LRsQ2aJpZUexUVk3o1E3ZIeM/joE+jFZ\nNX+rL0Aqmn0JVgKqZI2CbDB5AwJdSpUYd/m0Ko3E/Hxdu/CbeJqdjSl4ArVIyRBL\nJWY4aMbC81B6ftYGyjpBujXIoyTYNIhf+CYYXzNrsOkCgYEA8J4ajDpKtxowkbIj\nT+9FTY54d+SWcvwEKA22KayyFwx/mXWTnfsylzF6JbGAiZKSG9gbUOP1LsoGDsGj\nhFdLMSfmi151IbOJg1l74E7nM5bqW9ULGyLBOpWlvopXt31jV6uQd/t/+gdflyw0\nMtr642krwfz8UOshkeEIsk+7mmUCgYEA6X/omGsvMyLpa2IWjxwuw+51pCdIoZvL\n7BpV1YHqwO8jWVv1KKpOKzrYZVu93w0WMCHoG/g9FGQtOBmMRk2OKOxmCF+H1or4\nI1+iI/dhTPA2tEeAELX+yGtu4fpEHe+dga1QCNdq06366rn0bhWB5hst1DdVQnXn\n+0KjhLmg7DcCgYAxqQ/lnSpKfBdGGrP7DXEKPrtSU1VRyf25norYMxJWe3fiXkfn\nNS8N0WJaYTYcLqoFIScSHNo/m+aAKSrsZ2/XZ1rHrOkT2ZAqEc/lTaOeHCmmZmPy\nZ8vloXkhyD+uWSylrX0VpkyVd+wcsTzcuiFJyi0Dzojs0nqNNxqqYpZfmQKBgDep\npUIIcyUGkoxlwqj09/T/OI4cS0UzRaaQFJwkL1k06MFZmZTLHH1TtthayWWN0hdB\nTfq076KXyuvPs0/jFxuMVzpxw4kScdrE5nsactiLfw706IOTTxxp9/Ho3iogv/R0\n41poN/AkTmd8UteXSvMW0ZMAadPBFb8hAKgYNFN7AoGAbw6WYYPnhikP7gqWmTh0\n0SOeET5WbRfseiUWMfLGL+R5GmNiBhw63n8srz+KJVLJv0PJ/WKDR7o/Hxjv3w9c\ndkqcFG1MW2NKjrdxztptrRaSD7JyA750rB+CsrwvqzJCvwbulp1iRfWkTqq2fnUU\nQvpxhOYnq/ZlXPjUiE5w67w=\n-----END PRIVATE KEY-----';
+        content_by_lua '
+            local jwt = require "resty.jwt"
+
+            local jwt_token = jwt:sign(
+                ngx.var.key,
+                {
+                    header={
+                        typ="JWT",
+                        alg="RS256",
+                        x5c={"not a valid certificate", } },
+                    payload={foo="bar"}
+                }
+            )
+
+            local jwt_obj = jwt:verify(ngx.var.cert, jwt_token)
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+            ngx.say(jwt_obj["payload"]["foo"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+Malformed x5c header
+bar
+--- no_error_log
+[error]
+
+
+=== TEST 19: RS256 unsupported alg
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+
+            jwt:set_alg_whitelist({RS256=1})
+
+            local jwt_obj = jwt:verify(
+                "lua-resty-jwt",
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" ..
+                ".eyJmb28iOiJiYXIiLCJuYmYiOjk5OTk5OTk5OTl9" ..
+                ".Wfu3owxbzlrb0GXvV0D22Si8WEDP0WeRGwZNPAoYHMI",
+                9999999999
+            )
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+whitelist unsupported alg: HS256
+--- no_error_log
+[error]


### PR DESCRIPTION
This adds support for the public key crypto based RS256 algorithm.
Example usage:

    local PRIV = [[
    -----BEGIN PRIVATE KEY-----
    ...
    -----END PRIVATE KEY-----
    ]]
    local CERT = [[
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
    ]]

    local jwt = require("resty.jwt")
    local cjson = require("cjson")

    local cert, err = evp.Cert:new(CERT)
    local cert_der, err = cert:get_der()

    local jwt_token = jwt:sign(PRIV, {
        header={typ="JWT", alg="RS256", x5c={ngx.encode_base64(cert_der),}},
        payload={session_id = "123", user_id = "456", }
    })
    ngx.say("Signed JWT: ", jwt_token)
    jwt:set_trusted_certs_file("/path/to/my-ca-certificates.pem")
    local jwt_obj = jwt:verify(nil, jwt_token)
    ngx.say("Decoded JWT: ", cjson.encode(jwt_obj))
    ngx.exit(200)