### PR TITLE
Fix code to be tolerant of the optional TYP header

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -92,8 +92,7 @@ function _M.sign(self, secret_key, jwt_obj)
     -- header typ check
     local typ = jwt_obj["header"]["typ"]
     -- Optional header typ check [See http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-5.1]
-    if jwt_obj["header"]["typ"] ~= nil then 
-        local typ = jwt_obj["header"]["typ"]
+    if typ ~= nil then 
         if typ ~= "JWT" then
             error({reason="invalid typ: " .. typ})
         end

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -91,9 +91,14 @@ _M.alg_whitelist = nil
 function _M.sign(self, secret_key, jwt_obj)
     -- header typ check
     local typ = jwt_obj["header"]["typ"]
-    if typ ~= "JWT" then
-        error({reason="invalid typ: " .. typ})
+    -- Optional header typ check [See http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-5.1]
+    if jwt_obj["header"]["typ"] ~= nil then 
+        local typ = jwt_obj["header"]["typ"]
+        if typ ~= "JWT" then
+            error({reason="invalid typ: " .. typ})
+        end
     end
+
 
     -- assemble jwt parts
     local raw_header = get_raw_part("header", jwt_obj)


### PR DESCRIPTION
Some JWT token issuers such as Cloudfoundry UAA do not emit the typ header. This causes the table to have a nil value which causes an error that is swallowed. As per the draft ietf paper this header is optional, so modded the code to make it so.