### PR TITLE
[Wip] Enforce "exp" and "nbf" claim format

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -362,7 +362,7 @@ local function sign_jwe(secret_key, jwt_obj)
   local json_payload = cjson_encode(jwt_obj.payload)
   local cipher_text, iv, err = encrypt_payload( key, json_payload, jwt_obj.header.enc )
   if err then
-    error({reason="error while encryptiping payload. Error: " .. err})
+    error({reason="error while encrypting payload. Error: " .. err})
   end
   local alg = jwt_obj.header.alg
 

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -58,6 +58,7 @@ local str_const = {
   reason = "reason",
   verified = "verified",
   number = "number",
+  funct = "function",
   valid = "valid",
   internal_error = "internal error",
   everything_awesome = "everything is awesome~ :p"
@@ -342,7 +343,7 @@ _M.alg_whitelist = nil
 --                             of the 'x5u' attribute in a jwt and return the
 --                             matching certificate.
 function _M.set_x5u_content_retriever(self, retriever_function)
-  if type(retriever_function) ~= "function" then
+  if type(retriever_function) ~= str_const.funct then
     error("'retriever_function' is expected to be a function")
   end
   self.x5u_content_retriever = retriever_function

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -80,15 +80,15 @@ local function is_nil_or_positive_number(arg_value)
     if arg_value == nil then
         return true
     end
-    
+
     if type(arg_value) ~= str_const.number then
         return false
     end
-    
+
     if arg_value < 0 then
         return false
     end
-    
+
     return true
 end
 

--- a/t/sign-verify.t
+++ b/t/sign-verify.t
@@ -529,3 +529,103 @@ GET /t
 --- error_log
 'leeway' is expected to be a positive number of seconds.
 [error]
+
+
+=== TEST 23: JWT simple with invalid exp ("exp": "17") and default strict validation
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local jwt_obj = jwt:verify(
+                "lua-resty-jwt",
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ..
+                ".eyJmb28iOiJiYXIiLCJleHAiOiIxNyJ9" ..
+                ".6gWBliIuNT1qF_RhD1ymI-zRyN38zGme0dHvYkOFgxM"
+            )
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+jwt 'exp' claimed is malformed. Expected to be a positive numeric value.
+--- no_error_log
+[error]
+
+
+=== TEST 24: JWT simple with invalid exp ("exp": -17) and default strict validation
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local jwt_obj = jwt:verify(
+                "lua-resty-jwt",
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ..
+                ".eyJmb28iOiJiYXIiLCJleHAiOi0xN30" ..
+                ".Jd3_eeMBJeWAeyke5SbXD3TecVPpci7lNLWGze9OP9o"
+            )
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+jwt 'exp' claimed is malformed. Expected to be a positive numeric value.
+--- no_error_log
+[error]
+
+
+=== TEST 25: JWT simple with invalid nbf ("nbf": "17") and default strict validation
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local jwt_obj = jwt:verify(
+                "lua-resty-jwt",
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ..
+                ".eyJmb28iOiJiYXIiLCJuYmYiOiIxNyJ9" ..
+                ".kYzPvYDRiW37rsdYNfFd57KDBuZpm1loCRIJSUlQjbE"
+            )
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+jwt 'nbf' claimed is malformed. Expected to be a positive numeric value.
+--- no_error_log
+[error]
+
+
+=== TEST 26: JWT simple with invalid nbf ("nbf": -17) and default strict validation
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local jwt_obj = jwt:verify(
+                "lua-resty-jwt",
+                "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" ..
+                ".eyJmb28iOiJiYXIiLCJuYmYiOi0xN30" ..
+                ".jNUyAIYISmDcemGO3gE17byPZ_ZO-WZxaMt59UNslPc"
+            )
+            ngx.say(jwt_obj["verified"])
+            ngx.say(jwt_obj["reason"])
+        ';
+    }
+--- request
+GET /t
+--- response_body
+false
+jwt 'nbf' claimed is malformed. Expected to be a positive numeric value.
+--- no_error_log
+[error]


### PR DESCRIPTION
Fix #17

This can be tuned down through the `loose_validation(bool)` configuration function