### PR TITLE
Fail faster / Fail safer

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -802,8 +802,14 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, validation_options)
     local raw_payload = get_raw_part(str_const.payload, jwt_obj)
 
     local message =string_format(str_const.regex_join_msg, raw_header ,  raw_payload)
-    local sig = jwt_obj[str_const.signature]
-    local verified, err = verifier:verify(message, _M:jwt_decode(sig, false), evp.CONST.SHA256_DIGEST)
+    local sig = _M:jwt_decode(jwt_obj[str_const.signature], false)
+
+    if not sig then
+      jwt_obj[str_const.reason] = "Wrongly encoded signature"
+      return jwt_obj
+    end
+
+    local verified, err = verifier:verify(message, sig, evp.CONST.SHA256_DIGEST)
     if not verified then
       jwt_obj[str_const.reason] = err
     end

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -802,7 +802,7 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, validation_options)
     local raw_payload = get_raw_part(str_const.payload, jwt_obj)
 
     local message =string_format(str_const.regex_join_msg, raw_header ,  raw_payload)
-    local sig = jwt_obj[str_const.signature]:gsub(str_const.dash, str_const.plus):gsub(str_const.underscore, str_const.slash)
+    local sig = jwt_obj[str_const.signature]
     local verified, err = verifier:verify(message, _M:jwt_decode(sig, false), evp.CONST.SHA256_DIGEST)
     if not verified then
       jwt_obj[str_const.reason] = err


### PR DESCRIPTION
- Apply fast validators before slower signature validation
- Guard the signature verification process against bad base64 encoding (Was previsously causing a 500 server side :crying_cat_face: )