### PR TITLE
Update errors from validators to not include the location of the error.

### DIFF
--- a/lib/resty/jwt-validators.lua
+++ b/lib/resty/jwt-validators.lua
@@ -46,12 +46,12 @@ local messages = {
 
 -- Local function to make sure that a value is non-nil or raises an error
 local function ensure_not_nil(v, e, ...)
-  return v ~= nil and v or error(string.format(e, ...))
+  return v ~= nil and v or error(string.format(e, ...), 0)
 end
 
 -- Local function to make sure that a value is the given type
 local function ensure_is_type(v, t, e, ...)
-  return type(v) == t and v or error(string.format(e, ...))
+  return type(v) == t and v or error(string.format(e, ...), 0)
 end
 
 -- Local function to make sure that a value is a (non-empty) table
@@ -78,7 +78,7 @@ local function ensure_is_non_negative(v, e, ...)
     if v >= 0 then
       return v
     else
-      error(string.format(e, ...))
+      error(string.format(e, ...), 0)
     end
   end
 end
@@ -173,7 +173,7 @@ function _M.require_one_of(claim_keys)
       if val.payload[v] ~= nil then return true end
     end
     
-    error(string.format(messages.missing_claim, table.concat(claim_keys, ", ")))
+    error(string.format(messages.missing_claim, table.concat(claim_keys, ", ")), 0)
   end
 end
 
@@ -333,7 +333,7 @@ local function format_date_on_error(date_check_function, error_msg)
   return function(val, claim, jwt_json)
     local ret = date_check_function(val, claim, jwt_json)
     if ret == false then
-      error(string.format("'%s' claim %s %s", claim, error_msg, ngx.http_time(val)))
+      error(string.format("'%s' claim %s %s", claim, error_msg, ngx.http_time(val)), 0)
     end
     return true
   end

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -357,7 +357,7 @@ end
 --                             matching certificate.
 function _M.set_x5u_content_retriever(self, retriever_function)
   if type(retriever_function) ~= str_const.funct then
-    error("'retriever_function' is expected to be a function")
+    error("'retriever_function' is expected to be a function", 0)
   end
   self.x5u_content_retriever = retriever_function
 end
@@ -589,11 +589,11 @@ local function get_claim_spec_from_legacy_options(self, options)
   end
 
   if not is_nil_or_boolean(options[str_const.require_nbf_claim]) then
-    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_nbf_claim))
+    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_nbf_claim), 0)
   end
 
   if not is_nil_or_boolean(options[str_const.require_exp_claim]) then
-    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_exp_claim))
+    error(string.format("'%s' validation option is expected to be a boolean.", str_const.require_exp_claim), 0)
   end
 
   if options[str_const.lifetime_grace_period] ~= nil or options[str_const.require_nbf_claim] ~= nil or options[str_const.require_exp_claim] ~= nil then
@@ -656,13 +656,13 @@ local function validate_claims(self, jwt_obj, ...)
     end
     for claim, fx in pairs(claim_spec) do
       if type(fx) ~= str_const.funct then
-        error("Claim spec value must be a function - see jwt-validators.lua for helper functions")
+        error("Claim spec value must be a function - see jwt-validators.lua for helper functions", 0)
       end
       
       local val = claim == str_const.full_obj and cjson_decode(jwt_json) or jwt_obj.payload[claim]
       local success, ret = pcall(fx, val, claim, jwt_json)
       if not success then
-        jwt_obj[str_const.reason] = ret.reason or string.gsub(ret, "^.*: ", "")
+        jwt_obj[str_const.reason] = ret.reason or string.gsub(ret, "^.-:%d-: ", "")
         return false
       elseif ret == false then
         jwt_obj[str_const.reason] = string.format("Claim '%s' ('%s') returned failure", claim, val)


### PR DESCRIPTION
By passing `0` as the second parameter to error, the location of the error is not included.  For validators (and most other errors, IMO), that information is not really needed...the error message itself is the more interesting part.

Also fixed a small issue with parsing out the location in jwt.lua.  Matching `.*` is a greedy match - which means if the error message had a colon, the first part of the message got stripped as well when putting it into the `reason` field.

For those errors that return an object with a `reason` field, there are no changes.