### PR TITLE
Make x5u_content_retriever callback function accept the iss and kid claims

### DIFF
--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -415,13 +415,13 @@ local function get_secret_str(secret_or_function, jwt_obj)
     if alg ~= str_const.HS256 and alg ~= str_const.HS512 then
       error({reason="secret function can only be used with hmac alg: " .. alg})
     end
-    
+
     -- Pull out the kid value from the header
     local kid_val = jwt_obj[str_const.header][str_const.kid]
     if kid_val == nil then
       error({reason="secret function specified without kid in header"})
     end
-    
+
     -- Call the function
     return secret_or_function(kid_val) or error({reason="function returned nil for kid: " .. kid_val})
   elseif type(secret_or_function) == str_const.string then
@@ -580,7 +580,7 @@ local function get_claim_spec_from_legacy_options(self, options)
   end
 
   if options[str_const.lifetime_grace_period] ~= nil then
-    jwt_validators.set_system_leeway(options[str_const.lifetime_grace_period] or 0)    
+    jwt_validators.set_system_leeway(options[str_const.lifetime_grace_period] or 0)
 
     -- If we have a leeway set, then either an NBF or an EXP should also exist requireds are added below
     if options[str_const.require_nbf_claim] ~= true and options[str_const.require_exp_claim] ~= true then
@@ -616,7 +616,7 @@ end
 local function is_legacy_validation_options(options)
 
   -- Validation options MUST be a table
-  if type(options) ~= str_const.table then 
+  if type(options) ~= str_const.table then
     return false
   end
 
@@ -648,7 +648,7 @@ local function validate_claims(self, jwt_obj, ...)
 
   -- Encode the current jwt_obj and use it when calling the individual validation functions
   local jwt_json = cjson_encode(jwt_obj)
-  
+
   -- Validate all our specs
   for _, claim_spec in ipairs(claim_specs) do
     if is_legacy_validation_options(claim_spec) then
@@ -658,7 +658,7 @@ local function validate_claims(self, jwt_obj, ...)
       if type(fx) ~= str_const.funct then
         error("Claim spec value must be a function - see jwt-validators.lua for helper functions", 0)
       end
-      
+
       local val = claim == str_const.full_obj and cjson_decode(jwt_json) or jwt_obj.payload[claim]
       local success, ret = pcall(fx, val, claim, jwt_json)
       if not success then
@@ -670,7 +670,7 @@ local function validate_claims(self, jwt_obj, ...)
       end
     end
   end
-  
+
   -- Everything was good
   return true
 end

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -352,9 +352,12 @@ end
 --- Set a function used to retrieve the content of x5u urls
 --
 -- @param retriever_function - A pointer to a function. This function should be
---                             defined to accept one string parameter, the value
---                             of the 'x5u' attribute in a jwt and return the
---                             matching certificate.
+--                             defined to accept three string parameters. First one
+--                             will be the value of the 'x5u' attribute. Second
+--                             one will be the value of the 'iss' attribute, would
+--                             it be defined in the jwt. Third one will be the value
+--                             of the 'iss' attribute, would it be defined in the jwt.
+--                             This function should return the matching certificate.
 function _M.set_x5u_content_retriever(self, retriever_function)
   if type(retriever_function) ~= str_const.funct then
     error("'retriever_function' is expected to be a function", 0)
@@ -552,7 +555,9 @@ local function extract_certificate(jwt_obj, x5u_content_retriever)
     -- TODO Maybe validate the url against an optional list whitelisted url prefixes?
     -- cf. https://news.ycombinator.com/item?id=9302394
 
-    local success, ret = pcall(x5u_content_retriever, x5u)
+    local iss = jwt_obj[str_const.payload][str_const.iss]
+    local kid = jwt_obj[str_const.header][str_const.kid]
+    local success, ret = pcall(x5u_content_retriever, x5u, iss, kid)
 
     if not success then
       jwt_obj[str_const.reason] = "An error occured while invoking the x5u_content_retriever function."

--- a/t/load-verify.t
+++ b/t/load-verify.t
@@ -352,7 +352,15 @@ everything is awesome~ :p
         content_by_lua '
             local jwt = require "resty.jwt"
 
-            local function get_public_key(url)
+            local function get_public_key(url, iss, kid)
+                if iss ~= nil then
+                    error("Unexpected iss has been passed. Duh :(")
+                end
+
+                if kid ~= nil then
+                    error("Unexpected kid has been passed. Duh :(")
+                end
+
                 return ngx.var.cert
             end
 

--- a/t/sign-verify.t
+++ b/t/sign-verify.t
@@ -319,7 +319,15 @@ whitelist unsupported alg: HS256
         content_by_lua '
             local jwt = require "resty.jwt"
 
-            local function get_public_key(url)
+            local function get_public_key(url, iss, kid)
+                if iss ~= "Authz" then
+                    error("No issuer. Duh :(")
+                end
+
+                if kid ~= "IamAPubl1cKeV" then
+                    error("No key identifier. Duh :(")
+                end
+
                 return ngx.var.cert
             end
 
@@ -334,8 +342,9 @@ whitelist unsupported alg: HS256
                         typ="JWT",
                         alg="RS256",
                         x5u="https://dummy.com/certs",
+                        kid="IamAPubl1cKeV",
                     },
-                    payload={foo="bar", exp=9999999999}
+                    payload={foo="bar", iss="Authz", exp=9999999999}
                 }
             )
 


### PR DESCRIPTION
Should make it easier for consumers to plug in a cache storage of public key certs.