### PR TITLE
make jwe token verification compatible with RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,13 @@ sign-jwe
 
 sign a table_of_jwt to a jwt_token.
 
-The `alg` argument specifies which hashing algorithm to use for encrypting key (`DIR`).
-The `enc` argument specifies which hashing algorithm to use for encrypting payload (`A128CBC_HS256`, `A256CBC_HS512`)
+The `alg` argument specifies which hashing algorithm to use for encrypting key (`dir`).
+The `enc` argument specifies which hashing algorithm to use for encrypting payload (`A128CBC-HS256`, `A256CBC-HS512`)
 
 ### sample of table_of_jwt ###
 ```
 {
-    "header": {"typ": "JWE", "alg": "DIR", "enc":"A128CBC_HS256"},
+    "header": {"typ": "JWE", "alg": "dir", "enc":"A128CBC-HS256"},
     "payload": {"foo": "bar"}
 }
 ```
@@ -324,7 +324,7 @@ When using legacy `validation_options`, you *MUST ONLY* specify these options.  
     * When none of the `nbf` and `exp` claims can be found, verification will fail.
 
     * `nbf` and `exp` claims are expected to be expressed in the jwt as numerical values. Wouldn't that be the case, verification will fail.
-    
+
     * Specifying this option is equivalent to calling:
       ```
       validators.set_system_leeway(leeway)
@@ -342,7 +342,7 @@ When using legacy `validation_options`, you *MUST ONLY* specify these options.  
 * `require_nbf_claim`: Express if the `nbf` claim is optional or not. Value should be a boolean.
 
     * When this validation option is set to `true` and no `lifetime_grace_period` has been specified, a zero (`0`) leeway is implied.
-    
+
     * Specifying this option is equivalent to specifying as a `claim_spec`:
       ```
       {

--- a/lib/resty/jwt.lua
+++ b/lib/resty/jwt.lua
@@ -748,7 +748,7 @@ function _M.verify_jwt_obj(self, secret, jwt_obj, ...)
       jwt_obj[str_const.reason] = "signature mismatch: " .. jwt_obj[str_const.signature]
     end
   elseif alg == str_const.RS256 then
-    local cert
+    local cert, err
     if self.trusted_certs_file ~= nil then
       local cert_str = extract_certificate(jwt_obj, self.x5u_content_retriever)
       if not cert_str then
@@ -817,7 +817,7 @@ end
 
 
 function _M.verify(self, secret, jwt_str, ...)
-  jwt_obj = _M.load_jwt(self, jwt_str, secret)
+  local jwt_obj = _M.load_jwt(self, jwt_str, secret)
   if not jwt_obj.valid then
     return {verified=false, reason=jwt_obj[str_const.reason]}
   end

--- a/t/load-verify-jwe.t
+++ b/t/load-verify-jwe.t
@@ -1,0 +1,170 @@
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (3 * blocks());
+
+our $HttpConfig = <<'_EOC_';
+    lua_package_path 'lib/?.lua;;';
+_EOC_
+
+no_long_string();
+
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: Verify A256CBC-HS512 Direct Encryption with a Shared Symmetric Key
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234" ..
+                               "12341234123412341234123412341234"
+
+            local jwt_obj = jwt:verify(
+              shared_key,
+              "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIn0." ..
+              ".M927Z_hNTmumFQE0rtRQCQ.nnd7AoE_2dgvws2-iay8qA.d" ..
+              "kyZuuks4Qm9Cd7VfEVSs07pi_Kyt0INVHTTesUC2BM"
+            )
+            ngx.say(
+                cjson.encode(jwt_obj)
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+{"payload":{"foo":"bar"},"reason":"everything is awesome~ :p","header":{"alg":"dir","enc":"A256CBC-HS512"},"valid":true,"verified":true}
+--- no_error_log
+[error]
+
+=== TEST 2: Verify A128CBC-HS256 Direct Encryption with a Shared Symmetric Key
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234"
+
+            local jwt_obj = jwt:verify(
+                shared_key,
+                "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0." ..
+                ".U6emIwy_yVkagUwQ4EjdFA.FrapgQVvG3uictQz9NPPMw.n" ..
+                "MoW0ShdgCN0JHw472SJjQ"
+            )
+            ngx.say(
+                cjson.encode(jwt_obj)
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+{"payload":{"foo":"bar"},"reason":"everything is awesome~ :p","header":{"alg":"dir","enc":"A128CBC-HS256"},"valid":true,"verified":true}
+--- no_error_log
+[error]
+
+=== TEST 3: Dont fail if extra chars added
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234"
+
+            local jwt_obj = jwt:verify(
+                shared_key,
+                "eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0." ..
+                ".U6emIwy_yVkagUwQ4EjdFA.FrapgQVvG3uictQz9NPPMw.n" ..
+                "MoW0ShdgCN0JHw472SJjQ" ..
+                "xxx"
+
+            )
+            ngx.say(
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+valid: true
+verified: false
+--- no_error_log
+[error]
+
+=== TEST 4: Encode A128CBC-HS256 Direct Encryption
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234"
+
+            local table_of_jwt = {
+              header = { alg = "dir", enc = "A128CBC-HS256" },
+              payload = { foo = "bar" },
+            }
+
+            local jwt_token = jwt:sign(shared_key, table_of_jwt)
+            local jwt_obj = jwt:verify(shared_key, jwt_token)
+
+            ngx.say(
+                cjson.encode(table_of_jwt.payload) == cjson.encode(jwt_obj.payload), "\\n",
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+valid: true
+verified: true
+--- no_error_log
+[error]
+
+
+=== TEST 5: Encode A256CBC-HS512 Direct Encryption
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local jwt = require "resty.jwt"
+            local cjson = require "cjson"
+            local shared_key = "12341234123412341234123412341234" ..
+                               "12341234123412341234123412341234"
+
+            local table_of_jwt = {
+              header = { alg = "dir", enc = "A256CBC-HS512" },
+              payload = { foo = "bar" },
+            }
+
+            local jwt_token = jwt:sign(shared_key, table_of_jwt)
+            local jwt_obj = jwt:verify(shared_key, jwt_token)
+
+            ngx.say(
+                cjson.encode(table_of_jwt.payload) == cjson.encode(jwt_obj.payload), "\\n",
+                "valid: ", jwt_obj.valid, "\\n",
+                "verified: ", jwt_obj.verified
+            )
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+valid: true
+verified: true
+--- no_error_log
+[error]


### PR DESCRIPTION
- [x] fix key length
- [x] fix algorithm names
- [x] remove global vars
- [x] make `verify` compatible with [JWE RFC](https://tools.ietf.org/html/rfc7518#section-4.5)
- [x] make `sign` compatible with [JWE RFC](https://tools.ietf.org/html/rfc7518#section-4.5)
- [x] add tests for JWE