### PR TITLE
Feature - Table Based Custom Claim Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ Returns a validator that checks if a value exactly equals any of the given `chec
 #### `validators.matches_any_of(patterns)` (opt) ####
 Returns a validator that checks if a value matches any of the given `patterns`.
 
+#### `validators.contains_any_of(check_values,name)` (opt) ####
+Returns a validator that checks if a value of expected type `string` exists in any of the given `check_values`.  The value of `check_values`must be a non-empty table with all the same types.  The optional name is used for error messages and defaults to `check_values`.
+
 #### `validators.greater_than(check_val)` (opt) ####
 Returns a validator that checks how a value compares (numerically, using `>`) to a given `check_value`.  The value of `check_val` cannot be `nil` and must be a number.
 

--- a/lib/resty/jwt-validators.lua
+++ b/lib/resty/jwt-validators.lua
@@ -93,6 +93,18 @@ local function string_match_function(val, pattern)
   return string.match(val, pattern) ~= nil
 end
 
+--[[ 
+    A local function which returns truth on existence of check in vals.
+    Adopted from auth0/nginx-jwt table_contains by @twistedstream
+]]--
+local function table_contains_function(vals, check)
+    for _, val in pairs(vals) do
+        if val == check then return true end
+    end
+    return false
+end
+
+
 -- A local function which returns numeric greater than comparison
 local function greater_than_function(val, check)
   return val > check
@@ -270,6 +282,14 @@ define_validator("matches_any_of", function(patterns)
   return _M.opt_any_of(patterns, string_match_function, "patterns", "string", "string")
 end)
 
+--[[
+    Returns a validator that checks if a value of expected type string exists in any of the given values.
+    The value of check_values must be a non-empty table with all the same types.  
+    The optional name is used for error messages and defaults to "check_values".
+]]--
+define_validator("contains_any_of", function(check_values,name)
+  return _M.opt_any_of(check_values, table_contains_function, name, "table", "string")
+end)
 
 --[[
     Returns a validator that checks how a value compares (numerically) to a given 

--- a/lib/resty/jwt-validators.lua
+++ b/lib/resty/jwt-validators.lua
@@ -287,7 +287,7 @@ end)
     The value of check_values must be a non-empty table with all the same types.  
     The optional name is used for error messages and defaults to "check_values".
 ]]--
-define_validator("contains_any_of", function(check_values,name)
+define_validator("contains_any_of", function(check_values, name)
   return _M.opt_any_of(check_values, table_contains_function, name, "table", "string")
 end)
 

--- a/t/validators.t
+++ b/t/validators.t
@@ -1946,3 +1946,171 @@ GET /t
 [error]
 
 
+=== TEST 77: Validator.opt_contains_any_of
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local validators = require "resty.jwt-validators"
+            local tval = validators.opt_contains_any_of({ "roleFoo", "roleBar" }, "roles")
+            local obj1 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleFoo", "roleBaz" ] }
+            }
+            local obj2 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleBar", "roleBaz" ] }
+            }
+            local obj3 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles="roleFoo" }
+            }
+            local obj4 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleBoo", "roleBaz" ] }
+            }
+            __testValidator(tval, "roles", obj1)
+            __testValidator(tval, "roles", obj2)
+            __testValidator(tval, "roles", obj3)
+            __testValidator(tval, "roles", obj4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+Cannot create validator for non-table roles.
+false
+--- no_error_log
+[error]
+
+
+=== TEST 78: Validator.opt_contains_any_of number
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local validators = require "resty.jwt-validators"
+            __runSay(validators.opt_contains_any_of, { 41, 42 }, "table-claim")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+Cannot create validator for non-string table table-claim.
+--- no_error_log
+[error]
+
+
+=== TEST 79: Validator.opt_contains_any_of empty table
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local cjson = require "cjson.safe"
+            local validators = require "resty.jwt-validators"
+            __runSay(validators.opt_contains_any_of, {}, "table-claim")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+Cannot create validator for empty table table-claim.
+--- no_error_log
+[error]
+
+
+=== TEST 80: Validator.opt_contains_any_of invalid table
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local cjson = require "cjson.safe"
+            local validators = require "resty.jwt-validators"
+            __runSay(validators.opt_contains_any_of, "abc", "table-claim")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+Cannot create validator for non-table table-claim.
+--- no_error_log
+[error]
+
+
+=== TEST 81: Validator.opt_contains_any_of mixed type table
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local cjson = require "cjson.safe"
+            local validators = require "resty.jwt-validators"
+            __runSay(validators.opt_contains_any_of, { "abc", 123 }, "table-claim")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+Cannot create validator for non-string table table-claim.
+--- no_error_log
+[error]
+
+
+=== TEST 82: Validator.opt_contains_any_of non-string
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local cjson = require "cjson.safe"
+            local validators = require "resty.jwt-validators"
+            __runSay(validators.opt_contains_any_of, { 41, 42 }, "table-claim")
+        ';
+    }
+--- request
+GET /t
+--- response_body
+Cannot create validator for non-string table table-claim.
+--- no_error_log
+[error]
+
+
+=== TEST 83: Validator.contains_any_of
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua '
+            local validators = require "resty.jwt-validators"
+            
+            local tval = validators.contains_any_of({ "roleFoo", "roleBar" }, "roles")
+            local obj1 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleFoo", "roleBaz" ] }
+            }
+            local obj2 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleBar", "roleBaz" ] }
+            }
+            local obj3 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles="roleFoo" }
+            }
+            local obj4 = {
+              header = { type="JWT", alg="HS256" },
+              payload = { foo="bar", baz="boo", num=42, roles=[ "roleBaz", "roleBoo" ] }
+            }
+            __testValidator(tval, "roles", obj1)
+            __testValidator(tval, "roles", obj2)
+            __testValidator(tval, "roles", obj3)
+            __testValidator(tval, "roles", obj4)
+        ';
+    }
+--- request
+GET /t
+--- response_body
+true
+true
+Cannot create validator for non-table roles.
+false
+--- no_error_log
+[error]


### PR DESCRIPTION
Addresses Issue #49 with a validator that will traverse a table to check existence for at least one string matching value in passed table of `checked_values`.  This is motivated by adding a custom scope to the token payload, such as `roles`, which may contain one or more string values.
