### PR TITLE
Fix memory leak

### DIFF
--- a/lib/resty/evp.lua
+++ b/lib/resty/evp.lua
@@ -274,6 +274,8 @@ function Cert.new(self, payload)
     if not public_key then
         return nil, err
     end
+
+    ffi.gc(public_key, _C.EVP_PKEY_free)
     
     self.public_key = public_key
     return self, nil


### PR DESCRIPTION
Following change seems to fix memory leak in #64 

`valgrind -v --log-file=memcheck.log  --tool=memcheck --leak-check=full openresty-valgrind -c /srv/openresty-apigw/conf/nginx.conf -p /srv/openresty-apigw`

[memcheck.log](https://gist.github.com/kleht8/9b3df4da7e4e5a96bc99c6abb58a4f41)